### PR TITLE
fix a typo in logontracer.py

### DIFF
--- a/logontracer.py
+++ b/logontracer.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 #
 # LICENSE
-# Please refer to the LICENSE.txt in the https://github.com/JPCERTCC/aa-tools/
+# Please refer to the LICENSE.txt in the https://github.com/JPCERTCC/LogonTracer/
 #
 
 import os


### PR DESCRIPTION
I believe there is a typo in the header comment section of `logontracer.py`.
