### PR TITLE
restrict scipy requirement to version 1.2.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@ numpy
 py2neo==3.1.2
 python-evtx
 lxml
+scipy==1.2.1
 changefinder
 flask
 hmmlearn


### PR DESCRIPTION
scipy 1.3 (published May 17) moves several imports from `scipy.misc` to `scipy.special`, breaking the `changefinder` package. Since that package does not look actively maintained, I propose locking down the scipy version in the LogonTracer requirements.