### PR TITLE
allow option to change the websocket port

### DIFF
--- a/logontracer.py
+++ b/logontracer.py
@@ -81,6 +81,8 @@ NEO4J_PORT = "7474"
 WEB_PORT = 8080
 # Web application address
 WEB_HOST = "0.0.0.0"
+# Websocket port
+WS_PORT = 7687
 
 # Check Event Id
 EVENT_ID = [4624, 4625, 4662, 4768, 4769, 4776, 4672, 4720, 4726, 4728, 4729, 4732, 4733, 4756, 4757, 4719, 5137, 5141]
@@ -277,13 +279,13 @@ if args.host:
 # Web application index.html
 @app.route('/')
 def index():
-    return render_template("index.html", server_ip=NEO4J_SERVER, neo4j_password=NEO4J_PASSWORD, neo4j_user=NEO4J_USER)
+    return render_template("index.html", server_ip=NEO4J_SERVER, ws_port=WS_PORT, neo4j_password=NEO4J_PASSWORD, neo4j_user=NEO4J_USER)
 
 
 # Timeline view
 @app.route('/timeline')
 def timeline():
-    return render_template("timeline.html", server_ip=NEO4J_SERVER, neo4j_password=NEO4J_PASSWORD, neo4j_user=NEO4J_USER)
+    return render_template("timeline.html", server_ip=NEO4J_SERVER, ws_port=WS_PORT, neo4j_password=NEO4J_PASSWORD, neo4j_user=NEO4J_USER)
 
 
 # Web application logs

--- a/templates/index.html
+++ b/templates/index.html
@@ -319,7 +319,7 @@
   <script type="text/javascript">
     var neo = neo4j.default;
     //Neo4j access settings
-    var driver = neo.driver("bolt://{{ server_ip }}", neo.auth.basic("{{ neo4j_user }}", "{{ neo4j_password }}"));
+    var driver = neo.driver("bolt://{{ server_ip }}:{{ ws_port }}", neo.auth.basic("{{ neo4j_user }}", "{{ neo4j_password }}"));
     var session = driver.session();
     var cy = cytoscape();
     var rankpageUser = 0

--- a/templates/timeline.html
+++ b/templates/timeline.html
@@ -73,7 +73,7 @@
   <script type="text/javascript">
     var neo = neo4j.default;
     //Neo4j access settings
-    var driver = neo.driver("bolt://{{ server_ip }}", neo.auth.basic("{{ neo4j_user }}", "{{ neo4j_password }}"));
+    var driver = neo.driver("bolt://{{ server_ip }}:{{ ws_port }}", neo.auth.basic("{{ neo4j_user }}", "{{ neo4j_password }}"));
     var session = driver.session();
     //createAlltimeline();
 


### PR DESCRIPTION
Hi,

We face an issue with our deployment model, where the usual port 7687 for the websocket is not directly available for the browsers.
Thus this tiny PR to allow the destination ws port to be changed, either in the conf or via a command line option.

Regards,
CERTXLM