### PR TITLE
fix: changed utcTime(utcTimeES) select option default value.

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -448,14 +448,14 @@
       }
     }
 
-    var downMenu = '<select class="form-select" id="utcTime"><option value="Username">Time Zone</option>';
+    var downMenu = '<select class="form-select" id="utcTime"><option value="Time Zone">Time Zone</option>';
     for (i = +14; i >= -12; i--) {
       downMenu += '<option>' + i + '</option>';
     }
     downMenu += '</select>';
     document.getElementById("zoneTime").innerHTML = downMenu;
 
-    var downMenuES = '<div class="col-3"><select class="form-select" id="utcTimeES"><option value="Username">Time Zone</option>';
+    var downMenuES = '<div class="col-3"><select class="form-select" id="utcTimeES"><option value="Time Zone">Time Zone</option>';
     for (i = +14; i >= -12; i--) {
       downMenuES += '<option>' + i + '</option>';
     }


### PR DESCRIPTION
Hello, thanks for the excellent tool :)
I tried adding a fix that leads to an improvement in the error message. 

## What Changed
- changed `Upload Event Log File` : `Time zone` select option default value `Username` to `Time Zone`
  - to make the input check work correctly.

## Motivation and Context
When user does not set `Time Zone`, the error message is as follows.(`Upload failed!`)
<img width="1440" alt="スクリーンショット 2022-12-17 11 17 57" src="https://user-images.githubusercontent.com/41001169/208220335-c6560d9d-b37c-44be-b99b-c7965cea822b.png">

It seems that in this case an error message is expected that `Please set the time zone of the event logs.` as follows.
- https://github.com/JPCERTCC/LogonTracer/blob/v1.5.4/static/js/script.js#L1553-L1554
- https://github.com/JPCERTCC/LogonTracer/blob/v1.5.4/static/js/script.js#L1599-L1600

but, the default value for the `Time Zone` select option was `Username` as follows.
- https://github.com/JPCERTCC/LogonTracer/blob/v1.5.4/templates/index.html#L451
- https://github.com/JPCERTCC/LogonTracer/blob/v1.5.4/templates/index.html#L458

So I changed the default value in this PR.

## Evidence
After fixing it, I confirmed that the error message is as follows.(`Please set the time zone of the event logs.`)
<img width="1440" alt="スクリーンショット 2022-12-17 11 24 41" src="https://user-images.githubusercontent.com/41001169/208220345-e96005d8-22d8-467f-a39a-3a45ce41562a.png">

and I confirmed that uploading can be performed normally when `Time Zone` value is set.
<img width="1440" alt="スクリーンショット 2022-12-17 11 33 20" src="https://user-images.githubusercontent.com/41001169/208220350-5e83db72-03f5-42e6-8fcb-102134798c3d.png">

I would appreciate it if you could confirm it🙏 


