### PR TITLE
fix: check `timelineTypes` when `all` search clicked in timeline `Graph` view.

### DIFF
--- a/static/js/script.js
+++ b/static/js/script.js
@@ -1449,7 +1449,12 @@ function addCanvas(users) {
 
 function createAlltimeline() {
   var queryStr = 'MATCH (date:Date) MATCH (user:Username) RETURN date, user';
-  createTimeline(queryStr, "all");
+  var gtype = document.getElementById("timelineTypes").checked;
+  if (gtype) {
+    createTimeline(queryStr, "all");
+  } else {
+    createTimelineGraph(queryStr);
+  }
 }
 
 function searchTimeline() {


### PR DESCRIPTION
Hello, thank you for maintaining the tool :)
I found a issue that the graph was not drawn when `all` clicked in the timeline view, so I fixed it.

## What Changed
checking `timelineTypes`(A flag to identify the `table` view or `graph` view) when `all` clicked in the timeline view.

## Motivation and Context
The graph was not drawn when `all` is clicked(and `Graph` selected) on the timeline view  as follows. 
<img width="1253" alt="スクリーンショット 2022-12-20 23 24 17" src="https://user-images.githubusercontent.com/41001169/208689812-87024191-6c5c-4a58-8ca2-5842fc1f5b5a.png">

After investigating, I found that `createAlltimeline()` does not check `timelineTypes` as follows. 
https://github.com/JPCERTCC/LogonTracer/blob/v1.5.4/static/js/script.js#L1450-L1453

On the other hand, it is checked in `searchTimeline()` as follows.
https://github.com/JPCERTCC/LogonTracer/blob/v1.5.4/static/js/script.js#L1475-L1479

So, I fixed that checking `timelineTypes` in `createAlltimeline()`.

## Evidence
After fixing it, I confirmed that graph is drawn when `all` clicked.
<img width="1440" alt="スクリーンショット 2022-12-20 23 01 11" src="https://user-images.githubusercontent.com/41001169/208686264-e4a173ab-be82-4108-ad55-dabc8b15f5ca.png">

I would appreciate it if you could confirm it🙏 