### PR TITLE
fix docker-compose build error on M1 Mac

### DIFF
--- a/docker-compose/LogonTracer/build/Dockerfile
+++ b/docker-compose/LogonTracer/build/Dockerfile
@@ -8,10 +8,15 @@ RUN set -ex \
 		dpkg-dev \
 		gcc \
 		libssl-dev \
-		make
+		make \
+		curl \
+        build-essential
 
 ## LogonTracer install
 WORKDIR /usr/local/src
+
+RUN curl https://sh.rustup.rs -sSf | bash -s -- -y
+ENV PATH="/root/.cargo/bin:${PATH}"
 
 RUN git clone https://github.com/JPCERTCC/LogonTracer.git \
     && chmod 777 LogonTracer \


### PR DESCRIPTION
Hello, thank you so much  for maintaining the tool :)
I think M1 Mac may not be supported, but docker-compose succeeded on M1 Mac by the following method, so I'll send a PR.

## What Changed

- fixed docker-compose build error on M1 Mac(or `ARM` based os)
  - `pip install evtx` needs Rust tool chain on M1 Mac, so I added Rust installation in Dockerfile.

## Motivation and Context

docker-compose failed in the following environment.
The cause of `pip install evtx` error is that `evtx` needs Rust tool chain if docker OS arch is not as follows.
- https://github.com/omerbenamram/pyevtx-rs#wheels

### Environment

- Docker v20.10.21
- Docker Compose v2.13.0
- macOS Ventura(MacBook Air M1,2020)
```
uname -a
Darwin fooAir 22.2.0 Darwin Kernel Version 22.2.0: Fri Nov 11 02:04:44 PST 2022; root:xnu-8792.61.2~4/RELEASE_ARM64_T8103 arm64
```

### docker-compose build error
When I ran docker-compose build in the above environment, I got the following error.
`Cargo, the Rust package manager, is not installed or is not on PATH`

```
foo@fooAir docker-compose %docker-compose build
[+] Building 18.0s (7/9)
 => [internal] load build definition from Dockerfile                                                                                      0.0s
 => => transferring dockerfile: 1.16kB                                                                                                    0.0s
 => [internal] load .dockerignore                                                                                                         0.0s
 => => transferring context: 2B                                                                                                           0.0s
 => [internal] load metadata for docker.io/library/python:3.7.8-slim-buster                                                               2.4s
 => [1/6] FROM docker.io/library/python:3.7.8-slim-buster@sha256:716738248104b2c2c67f3d8f5c82e5c77e4ebae396fec29ea59a6bc3c9af18b1         0.0s
 => CACHED [2/6] RUN set -ex       && savedAptMark="$(apt-mark showmanual)"     && apt-get update     && apt-get install -y --no-install  0.0s
 => CACHED [3/6] WORKDIR /usr/local/src                                                                                                   0.0s
 => ERROR [4/6] RUN git clone https://github.com/JPCERTCC/LogonTracer.git     && chmod 777 LogonTracer   && chmod 777 LogonTracer/stati  15.5s
------
 > [4/6] RUN git clone https://github.com/JPCERTCC/LogonTracer.git     && chmod 777 LogonTracer                 && chmod 777 LogonTracer/static     && cd LogonTracer     && pip install cython     && pip install numpy     && pip install scipy     && pip install statsmodels     && pip install -r requirements.txt     && sed -i 's/\" -s \" + NEO4J_SERVER/\" -s neo4j\"/g' logontracer.py     && sed -i 's/+ NEO4J_SERVER +/+ \"neo4j\" +/g' logontracer.py     && sed -i 's/host=NEO4J_SERVER/host=\"neo4j\"/g' logontracer.py:
#0 0.203 Cloning into 'LogonTracer'...
#0 3.536 Collecting cython
#0 3.680   Downloading Cython-0.29.32-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.manylinux_2_24_aarch64.whl (1.8 MB)
#0 3.770 Installing collected packages: cython
#0 4.086 Successfully installed cython-0.29.32
#0 4.173 WARNING: You are using pip version 20.2.2; however, version 22.3.1 is available.
#0 4.173 You should consider upgrading via the '/usr/local/bin/python -m pip install --upgrade pip' command.
#0 4.608 Collecting numpy
#0 4.657   Downloading numpy-1.21.6-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl (13.0 MB)
#0 5.079 Installing collected packages: numpy
#0 6.021 Successfully installed numpy-1.21.6
#0 6.026 WARNING: You are using pip version 20.2.2; however, version 22.3.1 is available.
#0 6.026 You should consider upgrading via the '/usr/local/bin/python -m pip install --upgrade pip' command.
#0 6.364 Collecting scipy
#0 6.409   Downloading scipy-1.7.3-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl (36.1 MB)
#0 7.521 Requirement already satisfied: numpy<1.23.0,>=1.16.5 in /usr/local/lib/python3.7/site-packages (from scipy) (1.21.6)
#0 7.537 Installing collected packages: scipy
#0 9.178 Successfully installed scipy-1.7.3
#0 9.180 WARNING: You are using pip version 20.2.2; however, version 22.3.1 is available.
#0 9.180 You should consider upgrading via the '/usr/local/bin/python -m pip install --upgrade pip' command.
#0 9.443 Collecting statsmodels
#0 9.490   Downloading statsmodels-0.13.5-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl (9.6 MB)
#0 9.964 Collecting pandas>=0.25
#0 9.976   Downloading pandas-1.3.5-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl (10.7 MB)
#0 10.31 Collecting patsy>=0.5.2
#0 10.32   Downloading patsy-0.5.3-py2.py3-none-any.whl (233 kB)
#0 10.35 Collecting packaging>=21.3
#0 10.36   Downloading packaging-22.0-py3-none-any.whl (42 kB)
#0 10.37 Requirement already satisfied: scipy<1.8,>=1.3; python_version == "3.7" in /usr/local/lib/python3.7/site-packages (from statsmodels) (1.7.3)
#0 10.37 Requirement already satisfied: numpy>=1.17; python_version != "3.10" or platform_system != "Windows" or platform_python_implementation == "PyPy" in /usr/local/lib/python3.7/site-packages (from statsmodels) (1.21.6)
#0 10.39 Collecting python-dateutil>=2.7.3
#0 10.39   Downloading python_dateutil-2.8.2-py2.py3-none-any.whl (247 kB)
#0 10.47 Collecting pytz>=2017.3
#0 10.48   Downloading pytz-2022.7-py2.py3-none-any.whl (499 kB)
#0 10.52 Collecting six
#0 10.53   Downloading six-1.16.0-py2.py3-none-any.whl (11 kB)
#0 10.58 Installing collected packages: six, python-dateutil, pytz, pandas, patsy, packaging, statsmodels
#0 13.86 Successfully installed packaging-22.0 pandas-1.3.5 patsy-0.5.3 python-dateutil-2.8.2 pytz-2022.7 six-1.16.0 statsmodels-0.13.5
#0 13.87 WARNING: You are using pip version 20.2.2; however, version 22.3.1 is available.
#0 13.87 You should consider upgrading via the '/usr/local/bin/python -m pip install --upgrade pip' command.
#0 14.04 Requirement already satisfied: numpy in /usr/local/lib/python3.7/site-packages (from -r requirements.txt (line 1)) (1.21.6)
#0 14.09 Collecting py2neo>=2020.0.0
#0 14.14   Downloading py2neo-2021.2.3-py2.py3-none-any.whl (177 kB)
#0 14.39 Collecting evtx
#0 14.40   Downloading evtx-0.8.0.tar.gz (11 kB)
#0 14.40   Installing build dependencies: started
#0 15.34   Installing build dependencies: finished with status 'done'
#0 15.34   Getting requirements to build wheel: started
#0 15.37   Getting requirements to build wheel: finished with status 'done'
#0 15.37     Preparing wheel metadata: started
#0 15.40     Preparing wheel metadata: finished with status 'error'
#0 15.40     ERROR: Command errored out with exit status 1:
#0 15.40      command: /usr/local/bin/python /usr/local/lib/python3.7/site-packages/pip/_vendor/pep517/_in_process.py prepare_metadata_for_build_wheel /tmp/tmp482aieg5
#0 15.40          cwd: /tmp/pip-install-jv7v5vmd/evtx
#0 15.40     Complete output (6 lines):
#0 15.40
#0 15.40     Cargo, the Rust package manager, is not installed or is not on PATH.
#0 15.40     This package requires Rust and Cargo to compile extensions. Install it through
#0 15.40     the system's package manager or via https://rustup.rs/
#0 15.40
#0 15.40     Checking for Rust toolchain....
#0 15.40     ----------------------------------------
#0 15.40 ERROR: Command errored out with exit status 1: /usr/local/bin/python /usr/local/lib/python3.7/site-packages/pip/_vendor/pep517/_in_process.py prepare_metadata_for_build_wheel /tmp/tmp482aieg5 Check the logs for full command output.
#0 15.40 WARNING: You are using pip version 20.2.2; however, version 22.3.1 is available.
#0 15.40 You should consider upgrading via the '/usr/local/bin/python -m pip install --upgrade pip' command.
------
failed to solve: executor failed running [/bin/sh -c git clone https://github.com/JPCERTCC/LogonTracer.git     && chmod 777 LogonTracer 	&& chmod 777 LogonTracer/static     && cd LogonTracer     && pip install cython     && pip install numpy     && pip install scipy     && pip install statsmodels     && pip install -r requirements.txt     && sed -i 's/\" -s \" + NEO4J_SERVER/\" -s neo4j\"/g' logontracer.py     && sed -i 's/+ NEO4J_SERVER +/+ \"neo4j\" +/g' logontracer.py     && sed -i 's/host=NEO4J_SERVER/host=\"neo4j\"/g' logontracer.py]: exit code: 1
foo@fooAir docker-compose %
```

I would appreciate it if you could review it🙇
Regards.